### PR TITLE
Changed exfat-utils > exfat progs

### DIFF
--- a/1-setup.sh
+++ b/1-setup.sh
@@ -94,7 +94,7 @@ PKGS=(
 'dtc'
 'efibootmgr' # EFI boot
 'egl-wayland'
-'exfat-utils'
+'exfatprogs'
 'extra-cmake-modules'
 'filelight'
 'flex'


### PR DESCRIPTION
You have to use exfatprogs instead of exfat-utils to have exfat available in gparted and be able to mount exfat drives.